### PR TITLE
Fix word splitting, remove whitespace, clarify clear function.

### DIFF
--- a/fm.sh
+++ b/fm.sh
@@ -19,7 +19,7 @@ shopt -s extdebug
 
 bar()( printf '%s\n' "${BASH_ARGV[@]}" )
 foo=($(bar "${foo[@]}"))
-unset foo[-1]
+unset "foo[-1]"
 
 shopt -u extdebug
 }
@@ -118,7 +118,7 @@ read_keys
 case $key in
   Q) end;;
   D) printf '\e[H\e[2K%s' 'New directory name: '
-    
+
     read -r
     mkdir "$REPLY"&&{
       status='created' mark="4m$REPLY\e[m/"
@@ -129,7 +129,7 @@ case $key in
     }
   ;;
   F) printf '\e[H\e[2K%s' 'New file name: '
-    
+
     read -r
     >"$REPLY"&&{
       mark="9m$REPLY" status='created'
@@ -145,12 +145,12 @@ case $key in
   L|''|\[C) status='marked' path="$PWD"
     mark="${files[$cursor-$LINES]}"
     marked="${mark#[0-9]*m}" marked="${marked%\\e[m?}"
-    
+
     change_dir||{
       printf '\e[?1049l'
       clear&& cat "$marked"
       status='viewing'; hud
-      
+
       for((;;)){
         read_keys
         case $key in
@@ -171,8 +171,8 @@ case $key in
     read -rsn1
     [[ ${REPLY,,} == 'y' ]]&&{
       rm -fr "$path/$marked"&& status='deleted'
-      
-      [[ $marked == ${PWD##*/} ]]&&
+
+      [[ $marked == "${PWD##*/}" ]]&&
         change_dir ../|| get_files
     }|| printf '\e[2K'
   }

--- a/fm.sh
+++ b/fm.sh
@@ -5,7 +5,7 @@ export LC_ALL=C
 IFS='[;' read -sp $'\e[9999;9999H\e[6n' -d R -rs _ LINES _
 ((rows=LINES-1))
 
-clear(){ printf '\e[2J\e[%dH' "$rows"; }
+clear_rows(){ printf '\e[2J\e[%dH' "$rows"; }
 
 printf '\e[?1049h\e[?7l\e[?25l'
 
@@ -37,7 +37,7 @@ term(){ [[ $TERM =~ 256 ]]&& :; }
 
 get_files()
 {
-clear
+clear_rows
 unset files
 IFS=$'\n'
 for fp in "$PWD"/*; do
@@ -148,7 +148,7 @@ case $key in
 
     change_dir||{
       printf '\e[?1049l'
-      clear&& cat "$marked"
+      clear_rows&& cat "$marked"
       status='viewing'; hud
 
       for((;;)){
@@ -162,7 +162,7 @@ case $key in
     }
 
     printf '\e[?1049h\e[?25l'
-    clear&& draw_files; hud
+    clear_rows&& draw_files; hud
   ;;
   X|\[3) [[ $marked ]]&&{
     printf '\e[H\e[2K%b' \


### PR DESCRIPTION
Double quoting is necessary to prevent word splitting in Bash. In this particular case it's inevitable someone will have a space in the file or directory name which will break fm.sh.

Found random white space tabs in several places. Bash rarely interprets white space, but why risk it?

Clear is a command on the command line. Ideally we don't define functions with a name of a command line tool, or built-in function. It doesn't hurt anything until you decide you need the default function later.

There's a lot more optimization that can be done yet, but I'm starting here to see if you're interested before I spend a lot of time. Otherwise, great work so far!