### PR TITLE
correct editor selection; fix && || logic error

### DIFF
--- a/fm
+++ b/fm
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
-export LC_ALL=C
+LC_ALL=C
+LANG=C
 
 IFS='[;' read -sp $'\e[9999;9999H\e[6n' -d R -rs _ LINES _
 ((rows=LINES-1))
@@ -11,8 +12,7 @@ printf '\e[?1049h\e[?7l\e[?25l'
 
 end(){ printf '\e[?1049l\e[?7h\e[?25h'&& exit; }
 
-reverse()
-{
+reverse(){
 local -n foo="$1"
 
 shopt -s extdebug
@@ -26,8 +26,7 @@ shopt -u extdebug
 
 draw_files(){ printf '\e[3%b\e[m\n' "${files[@]}" ;}
 
-hud()
-{
+hud(){
 printf '\e[%dH\e[2K\e[44mfm\e[m%s\e[3%b\e[m %s' \
   "$LINES" "${status:+ | ${status^}: }" \
   "${mark:+$mark |}" '[←]back [→]open [q]uit'
@@ -35,8 +34,7 @@ printf '\e[%dH\e[2K\e[44mfm\e[m%s\e[3%b\e[m %s' \
 
 term(){ [[ $TERM =~ 256 ]]&& :; }
 
-get_files()
-{
+get_files(){
 clear_rows
 unset files
 IFS=$'\n'
@@ -66,8 +64,7 @@ draw_files
 hud
 }
 
-hover()
-{
+hover(){
 printf '\e[%dH\e[4%b\e[m' "$cursor" "${files[$cursor-$LINES]}"
 
 hist+=("$cursor"); (( cursor == hist ))||
@@ -76,44 +73,40 @@ hist+=("$cursor"); (( cursor == hist ))||
 (( i ))&& hist=("${hist[@]:1}")|| i=1
 }
 
-scroll()
-{
-(( fileCount > rows ))&&{
-  if (( cursor < 1 )); then
-    files=("${files[@]:0:${#files[@]}-$rows}")
-    cursor="$rows"&& draw_files
-  elif (( cursor > rows )); then
-    files=("${filesOG[@]:0:${#files[@]}+$rows}")
-    cursor=1&& draw_files
-  fi
-  hud
-}||{
-  ((cursorMin=LINES-${#files[@]}))
-  if (( cursor > rows )); then
-    cursor="$cursorMin"
-  elif (( cursor < cursorMin )); then
-    cursor="$rows"
-  fi
-}
+scroll(){
+    if (( fileCount > rows )); then
+        if (( cursor < 1 )); then
+            files=("${files[@]:0:${#files[@]}-$rows}")
+            cursor="$rows"&& draw_files
+        elif (( cursor > rows )); then
+            files=("${filesOG[@]:0:${#files[@]}+$rows}")
+            cursor=1&& draw_files
+        fi
+        hud
+    else
+        ((cursorMin=LINES-${#files[@]}))
+        if (( cursor > rows )); then
+            cursor="$cursorMin"
+        elif (( cursor < cursorMin )); then
+            cursor="$rows"
+        fi
+    fi
 }
 
-read_keys()
-{
+read_keys(){
 read -rsn1 key
 [[ $key == $'\e' ]]&& read -rsn2 key
 key="${key^^}"
 }
 
-change_dir()
-{
+change_dir(){
 cd "${1:-$marked}"&&{
   get_files
   cursor="$rows"
 }|| return
 }
 
-mapkeys()
-{
+mapkeys(){
 read_keys
 case $key in
   Q) end;;
@@ -156,7 +149,7 @@ case $key in
         case $key in
           Q) end;;
           H|\[D) status='marked'&& get_files&& break;;
-          L|\[C) "${EDITOR:-${VISUAL:-vi}}" "$marked";;
+          L|\[C) "${VISUAL:-${EDITOR:-vi}}" "$marked";;
         esac
       }
     }


### PR DESCRIPTION
First of all, excellent use of `$VISUAL`, `$EDITOR`, and the expansion to include `vi`. I updated the order to match how `git`, `visudo`, `less`, etc select an editor. In each case they check `$VISUAL` first. For that reason, you can sometimes find `.bashrc` examples like this:
`export VISUAL=/usr/bin/vim`
`export EDITOR="$VISUAL"`

Another great choice to include `LC_ALL=C`. Unfortunately, `LC_ALL=C` leaves `LANG` untouched so additional gains can be made by setting `LANG=C`. It doesn't hurt anything to use `export` as you had it, however, if you really only mean to set it in the script, your intention is more clear without it.

I made all the functions match in the sense that you had already decided (rightly so IMO) to use compact notation when reasonable (i.e. `clear_rows(){ printf '\e[2J\e[%dH' "$rows"; }`) so having the carriage returns in the rest of your functions doesn't make as much sense.

And finally, I had to fix your most egregious "bashism" in the `scroll` function. It's your program so I definitely don't want to tell you how to do it, but I hope you'll agree this both looks nicer, and removes any potential for logical errors. I may have also changed it to the more common tab spacing of 4...again totally up to you.